### PR TITLE
Change BrowserRouter to HashRouter

### DIFF
--- a/packages/iplease-client-student/src/index.tsx
+++ b/packages/iplease-client-student/src/index.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 
 import App from './App';
 
@@ -11,8 +11,8 @@ const root = createRoot(container!); // createRoot(container!) if you use TypeSc
 
 root.render(
   <StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## 작업 내용

webpack dev server에서 루트 페이지를 제외한 모든 페이지에서 새로고침이 되지 않는 이슈가 있다.
React Router는 내부적으로 history api를 사용하기 때문에 미지정 경로로 이동했을때 혹은 그 상태에서 refresh를 했을때(새로고침)와 같은 경우에도 애플리케이션이 적절히 렌더링을 할 수 있다.

하지만 webpack의 historyApiFallback 옵션을 true로 설정하여도 해당 기능이 작동하지 않았고, 해당 문제가 babel과 관련이 있어보여 해결하려 하였지만, 해결 과정중 너무 많은 시간이 소비되었고, 최종 배포일이 다가오는 마당에 아직 전체 기능도 완성되지 않았으며, 검색 엔진 최적화를 할 필요가 없는 어플리케이션이므로 "우선" HashRouter를 사용하여 운영중에 해결방법을 강구해보기로 결정하였다